### PR TITLE
trigger PR workflow that fails to `tfmigrate plan`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# tfmigrate-demo
+# tfmigrate-demo 
 
 A demo showing how [tfmigrate](https://github.com/minamijoyo/tfmigrate) can be
 used to automate the migration of Terraform resources between root module


### PR DESCRIPTION
This PR should fail to `tfmigrate plan`, as the `local_file.bar` resource declaration has not been moved from `project-one`'s HCL to `project-two`'s HCL. For this reason, the `tfmigrate` migration would migrate its `tfstate` definition, but the HCL left in `main.tf` would continue to reflect the pre-migration configuration.

See https://github.com/mdb/tfmigrate-demo/actions/runs/5776326609/job/15655320734.